### PR TITLE
Fix map.js syntax error

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -3,11 +3,11 @@ import { fetchJSON, el } from './utils.js';
 // OpenLayers imports via global ol (from CDN). Avoid ESM for simplicity on GH Pages.
 const { Map, View } = ol;
 const { OSM, XYZ } = ol.source;
-const { Tile as TileLayer, Vector as VectorLayer } = ol.layer;
-const { Vector as VectorSource } = ol.source;
+const { Tile: TileLayer, Vector: VectorLayer } = ol.layer;
+const { Vector: VectorSource } = ol.source;
 const { fromLonLat } = ol.proj;
 const { GeoJSON } = ol.format;
-const { Fill, Stroke, Style, Circle as CircleStyle, Icon } = ol.style;
+const { Fill, Stroke, Style, Circle: CircleStyle, Icon } = ol.style;
 const { defaults: defaultControls } = ol.control;
 const { defaults: defaultInteractions, Select } = ol.interaction;
 const { Overlay } = ol;


### PR DESCRIPTION
Fix `SyntaxError: Unexpected identifier 'as'` by replacing TypeScript-style aliasing with valid JavaScript colon-based aliases in object destructuring.

---
<a href="https://cursor.com/background-agent?bcId=bc-390d2641-b0ed-4378-91ac-d09ee79984f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-390d2641-b0ed-4378-91ac-d09ee79984f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

