### PR TITLE
Analyze basemap display issue

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -1,6 +1,7 @@
 import { fetchJSON, el } from './utils.js';
 
-// OpenLayers imports via global ol (from CDN). Avoid ESM for simplicity on GH Pages.
+// OpenLayers imports via global namespace (loaded from CDN)
+const ol = window.ol;
 const { Map, View } = ol;
 const { OSM, XYZ } = ol.source;
 const { Tile: TileLayer, Vector: VectorLayer } = ol.layer;

--- a/map.html
+++ b/map.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="./css/base.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ol@latest/ol.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ol@v7.4.0/ol/ol.css">
     <style>
       .ol-popup { position: absolute; background: var(--card); padding: 8px; border-radius: 12px; border: 1px solid var(--stroke); min-width: 220px; }
       .ol-popup .title{ font-weight:600; margin-bottom:4px; }
@@ -54,7 +54,7 @@
     <!-- Image modal -->
     <div id="imgModal" class="modal" aria-hidden="true"><img id="modalImg" alt="photo" /></div>
 
-    <script src="https://cdn.jsdelivr.net/npm/ol@latest/dist/ol.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/ol@v7.4.0/dist/ol.js"></script>
     <script type="module" src="./js/utils.js"></script>
     <script type="module" src="./js/auth-guard.js"></script>
     <script type="module" src="./js/map.js"></script>


### PR DESCRIPTION
Pin OpenLayers to a stable version and correct its loading to fix the basemap not showing.

The `@latest` CDN link for OpenLayers could resolve to versions that no longer expose the `ol` object globally, leading to `ol` being undefined in `map.js`. Additionally, the CSS path was incorrect. Pinning to `v7.4.0` and explicitly referencing `window.ol` ensures the library loads correctly and the global `ol` namespace is available for map initialization.

---
<a href="https://cursor.com/background-agent?bcId=bc-6c529bf3-6987-4f12-b03d-aa45061cad26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6c529bf3-6987-4f12-b03d-aa45061cad26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

