### PR TITLE
Fix basemap not showing cursor ai code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # WebGIS-Deli-Serdang
+
+## Notes on basemap not showing
+
+- This app uses OpenLayers loaded from CDN.
+- The CSS link must be `https://cdn.jsdelivr.net/npm/ol@v7.4.0/ol.css` (not `ol/ol.css`).
+- If the map shows controls but no tiles, ensure:
+  - The OpenLayers CSS URL is correct and loads (200 status).
+  - `.map-container` has size; in this repo it's fixed to viewport in `css/base.css`.
+  - Network access to tile servers is allowed (OSM, Stamen, Esri endpoints).
+  - No ad-block or CORS issues in the browser console.
+
+## Local development
+
+Open `index.html` with a static server (avoid `file://`). Any simple server works, for example:
+
+```bash
+python3 -m http.server 5173  # or: npx http-server
+```
+
+Then navigate to `/login.html` → sign in (any credentials) → `Open Map`.

--- a/map.html
+++ b/map.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="./css/base.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ol@v7.4.0/ol/ol.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ol@v7.4.0/ol.css">
     <style>
       .ol-popup { position: absolute; background: var(--card); padding: 8px; border-radius: 12px; border: 1px solid var(--stroke); min-width: 220px; }
       .ol-popup .title{ font-weight:600; margin-bottom:4px; }


### PR DESCRIPTION
Correct OpenLayers CSS URL to fix basemap not showing and add troubleshooting notes to `README.md`.

The basemap was not rendering because the OpenLayers CSS file was not loading due to an incorrect URL (`ol/ol.css` instead of `ol.css`), which caused the map viewport to appear blank or collapsed.

---
<a href="https://cursor.com/background-agent?bcId=bc-51d5233a-d28e-470c-8d75-f4cd240cd125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-51d5233a-d28e-470c-8d75-f4cd240cd125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

