### PR TITLE
Fix basemap not showing on Vercel

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -16,30 +16,45 @@ const { Overlay } = ol;
 const centerLonLat = [106.827153, -6.175392]; // Jakarta Monas as example center
 const center = fromLonLat(centerLonLat);
 
-const osm = new TileLayer({ source: new OSM(), visible: true });
-const stamen = new TileLayer({
+const osm = new TileLayer({ 
+  source: new OSM(), 
+  visible: true 
+});
+
+const cartoDB = new TileLayer({
   source: new XYZ({
-    url: 'https://stamen-tiles.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png',
-    attributions: 'Map tiles by Stamen Design',
-    maxZoom: 20
+    url: 'https://{a-d}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png',
+    attributions: '© OpenStreetMap contributors, © CARTO',
+    maxZoom: 20,
+    crossOrigin: 'anonymous'
   }),
   visible: false
 });
+
 const esriSat = new TileLayer({
   source: new XYZ({
-    url: 'https://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
-    attributions: 'Source: Esri, Maxar, Earthstar Geographics',
-    maxZoom: 20
+    url: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
+    attributions: '© Esri, Maxar, Earthstar Geographics',
+    maxZoom: 19,
+    crossOrigin: 'anonymous'
   }),
   visible: false
 });
 
 const map = new Map({
   target: 'map',
-  layers: [osm, stamen, esriSat],
+  layers: [osm, cartoDB, esriSat],
   view: new View({ center, zoom: 11 }),
   controls: defaultControls({ attribution: true }),
   interactions: defaultInteractions()
+});
+
+// Error handling for tile loading
+[osm, cartoDB, esriSat].forEach((layer, idx) => {
+  const source = layer.getSource();
+  source.on('tileloaderror', (event) => {
+    console.warn(`Tile loading error for layer ${idx}:`, event);
+  });
 });
 
 // Vector layers
@@ -81,7 +96,7 @@ map.addLayer(pointsLayer);
 // Basemap switching
 function setBasemap(name){
   osm.setVisible(name === 'osm');
-  stamen.setVisible(name === 'stamen');
+  cartoDB.setVisible(name === 'carto');
   esriSat.setVisible(name === 'sat');
 }
 

--- a/map.html
+++ b/map.html
@@ -35,8 +35,8 @@
       <div style="margin-top:8px;">
         <div>
           <div style="font-weight:600; margin:8px 0 6px;">Basemap</div>
-          <label><input type="radio" name="basemap" value="osm" checked /> OSM</label><br/>
-          <label><input type="radio" name="basemap" value="stamen" /> Stamen Toner Lite</label><br/>
+          <label><input type="radio" name="basemap" value="osm" checked /> OpenStreetMap</label><br/>
+          <label><input type="radio" name="basemap" value="carto" /> CartoDB Light</label><br/>
           <label><input type="radio" name="basemap" value="sat" /> ESRI Satellite</label>
         </div>
         <div style="font-weight:600; margin:12px 0 6px;">Operational Layers</div>


### PR DESCRIPTION
Replace deprecated Stamen basemap with CartoDB Light and update ESRI Satellite URL to fix basemap not showing on Vercel.

The previous Stamen tiles URL was deprecated and required an API key, causing the basemap to fail loading. This PR updates to CartoDB Light, a reliable and free alternative, and ensures the ESRI Satellite layer uses a stable URL, along with adding tile loading error handling.

---
<a href="https://cursor.com/background-agent?bcId=bc-f27f4047-99f4-40fb-8b7d-5aa9c65ba8e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f27f4047-99f4-40fb-8b7d-5aa9c65ba8e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

