### PR TITLE
Fix basemap not showing on Vercel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # WebGIS-Deli-Serdang
+
+Basemap telah diperbaiki agar tampil di Vercel dengan sumber tiles yang CORS-friendly dan HTTPS. Sumber saat ini:
+
+- OSM: `https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png`
+- CARTO Positron: `https://{a-d}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png`
+- ESRI World Imagery
+
+Catatan: Tidak diperlukan API key. Jika mengganti provider, pastikan mendukung CORS dan HTTPS.

--- a/js/map.js
+++ b/js/map.js
@@ -16,20 +16,43 @@ const { Overlay } = ol;
 const centerLonLat = [106.827153, -6.175392]; // Jakarta Monas as example center
 const center = fromLonLat(centerLonLat);
 
-const osm = new TileLayer({ source: new OSM(), visible: true });
+// Use robust, HTTPS-only, CORS-friendly basemap sources for production hosting
+const osm = new TileLayer({
+  source: new XYZ({
+    urls: [
+      'https://a.tile.openstreetmap.org/{z}/{x}/{y}.png',
+      'https://b.tile.openstreetmap.org/{z}/{x}/{y}.png',
+      'https://c.tile.openstreetmap.org/{z}/{x}/{y}.png'
+    ],
+    attributions: '© OpenStreetMap contributors',
+    maxZoom: 19,
+    crossOrigin: 'anonymous'
+  }),
+  visible: true
+});
+
+// Light basemap (Carto Positron) as a Stamen-like alternative without API key
 const stamen = new TileLayer({
   source: new XYZ({
-    url: 'https://stamen-tiles.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png',
-    attributions: 'Map tiles by Stamen Design',
-    maxZoom: 20
+    urls: [
+      'https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png',
+      'https://b.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png',
+      'https://c.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png',
+      'https://d.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png'
+    ],
+    attributions: '© OpenStreetMap contributors, © CARTO',
+    maxZoom: 20,
+    crossOrigin: 'anonymous'
   }),
   visible: false
 });
+
 const esriSat = new TileLayer({
   source: new XYZ({
     url: 'https://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
     attributions: 'Source: Esri, Maxar, Earthstar Geographics',
-    maxZoom: 20
+    maxZoom: 20,
+    crossOrigin: 'anonymous'
   }),
   visible: false
 });


### PR DESCRIPTION
Update basemap tile sources to ensure maps display correctly on Vercel.

Previous basemap providers (e.g., Stamen) often experienced CORS or rate-limit issues when deployed on Vercel. This PR replaces problematic sources with stable, HTTPS, and CORS-friendly alternatives like CARTO Positron and explicitly configures `crossOrigin: 'anonymous'` for all XYZ tile layers, including OSM and ESRI.

---
<a href="https://cursor.com/background-agent?bcId=bc-4eba0c70-f837-4f7d-9561-f82f223d4cfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4eba0c70-f837-4f7d-9561-f82f223d4cfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

