### PR TITLE
Fix homepage menu circle display

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -24,13 +24,13 @@ body{
 
 .home{ display:grid; place-items:center; padding:40px 16px; }
 .menu-grid{ display:grid; grid-template-columns: repeat(4, minmax(120px, 1fr)); gap:28px; max-width:1100px; width:100%; }
-.menu-item{ display:flex; flex-direction:column; align-items:center; justify-content:center; height:140px; border-radius:50%; text-decoration:none; color:var(--text); background:var(--card); border:1px solid var(--stroke); box-shadow: 0 10px 30px rgba(0,0,0,0.06), inset 0 1px 0 rgba(255,255,255,0.6); transition: transform .25s ease, box-shadow .25s ease, background .25s ease; }
+.menu-item{ display:flex; flex-direction:column; align-items:center; justify-content:center; aspect-ratio: 1 / 1; border-radius:50%; text-decoration:none; color:var(--text); background:var(--card); border:1px solid var(--stroke); box-shadow: 0 10px 30px rgba(0,0,0,0.06), inset 0 1px 0 rgba(255,255,255,0.6); transition: transform .25s ease, box-shadow .25s ease, background .25s ease; }
 .menu-item:hover{ transform: translateY(-4px); box-shadow: 0 18px 40px rgba(0,0,0,0.10); }
 .menu-item .icon{ font-size:28px; margin-bottom:10px; }
 .menu-item .label{ font-weight:600; letter-spacing:0.2px; }
 
 @media (max-width: 900px){ .menu-grid{ grid-template-columns: repeat(3, 1fr); } }
-@media (max-width: 640px){ .menu-grid{ grid-template-columns: repeat(2, 1fr); } .menu-item{ height:120px; } }
+@media (max-width: 640px){ .menu-grid{ grid-template-columns: repeat(2, 1fr); } }
 
 .card{ border-radius: var(--radius); background: var(--card); border:1px solid var(--stroke); box-shadow: 0 10px 30px rgba(0,0,0,0.06), inset 0 1px 0 rgba(255,255,255,0.6); }
 .btn{ display:inline-flex; align-items:center; gap:8px; padding:10px 14px; border-radius:12px; background: linear-gradient(180deg, #fff, #f3f4f6); border:1px solid var(--stroke); color:var(--text); text-decoration:none; font-weight:600; box-shadow: 0 2px 0 rgba(0,0,0,0.06); transition: transform .2s ease, box-shadow .2s ease; }


### PR DESCRIPTION
Ensure homepage menu items are perfect circles by using `aspect-ratio` instead of fixed height.

Previously, the menu items could appear as ellipses because their `height` was fixed while their `width` was determined by the grid layout, leading to an inconsistent aspect ratio. By setting `aspect-ratio: 1 / 1`, the width and height are always equal, guaranteeing a circular shape across all screen sizes.

---
<a href="https://cursor.com/background-agent?bcId=bc-e229a97a-ce68-43df-9a03-432abffb726f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e229a97a-ce68-43df-9a03-432abffb726f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

