### PR TITLE
Fix chrome console errors

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -9,8 +9,10 @@ const { Vector: VectorSource } = ol.source;
 const { fromLonLat } = ol.proj;
 const { GeoJSON } = ol.format;
 const { Fill, Stroke, Style, Circle: CircleStyle, Icon } = ol.style;
-const { defaults: defaultControls } = ol.control;
-const { defaults: defaultInteractions, Select } = ol.interaction;
+// In the UMD build, defaults are nested under `.defaults`
+const defaultControls = ol.control.defaults.defaults;
+const defaultInteractions = ol.interaction.defaults.defaults;
+const { Select } = ol.interaction;
 const { Overlay } = ol;
 
 const centerLonLat = [106.827153, -6.175392]; // Jakarta Monas as example center


### PR DESCRIPTION
Fix `defaultControls is not a function` error by updating OpenLayers UMD default accessors in `js/map.js`.

The OpenLayers UMD build nests its default controls and interactions under an additional `.defaults` property, causing the original destructuring to fail. This change correctly accesses these properties to resolve the console error.

---
<a href="https://cursor.com/background-agent?bcId=bc-02df3a58-b519-49eb-911c-3be54ac910b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-02df3a58-b519-49eb-911c-3be54ac910b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

