### PR TITLE
Clean up map display elements

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -47,7 +47,9 @@ const map = new Map({
   target: 'map',
   layers: [osm, cartoDB, esriSat],
   view: new View({ center, zoom: 11 }),
-  controls: defaultControls({ attribution: true }),
+  // Remove default OL UI controls; we provide custom ones in the UI.
+  // Also hides basemap attribution text.
+  controls: defaultControls({ attribution: false, zoom: false, rotate: false }),
   interactions: defaultInteractions()
 });
 


### PR DESCRIPTION
Remove default OpenLayers controls and hide basemap attribution to fix unwanted overlay tools and detail text.

---
<a href="https://cursor.com/background-agent?bcId=bc-babc42b7-af61-4471-a2c9-764e439d7cd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-babc42b7-af61-4471-a2c9-764e439d7cd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

