### PR TITLE
Set vanta background on homepage only

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -52,25 +52,6 @@
     <script>
       document.getElementById('year').textContent = new Date().getFullYear();
     </script>
-    <!-- Vanta.js background -->
-    <script src="https://cdn.jsdelivr.net/npm/three@0.134.0/build/three.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/vanta@0.5.24/dist/vanta.net.min.js"></script>
-    <script>
-      VANTA.NET({
-        el: "body",
-        mouseControls: true,
-        touchControls: true,
-        gyroControls: false,
-        minHeight: 200.00,
-        minWidth: 200.00,
-        scale: 1.00,
-        scaleMobile: 1.00,
-        color: 0x40000,
-        backgroundColor: 0xdedede,
-        points: 12.00,
-        maxDistance: 12.00,
-        spacing: 12.00
-      });
-    </script>
+    
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
         scale: 1.00,
         scaleMobile: 1.00,
         color: 0x40000,
-        backgroundColor: 0xdedede,
+        backgroundColor: 0xffffff,
         points: 12.00,
         maxDistance: 12.00,
         spacing: 12.00

--- a/login.html
+++ b/login.html
@@ -37,25 +37,6 @@
     </main>
     <script type="module" src="./js/utils.js"></script>
     <script type="module" src="./js/auth.js"></script>
-    <!-- Vanta.js background -->
-    <script src="https://cdn.jsdelivr.net/npm/three@0.134.0/build/three.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/vanta@0.5.24/dist/vanta.net.min.js"></script>
-    <script>
-      VANTA.NET({
-        el: "body",
-        mouseControls: true,
-        touchControls: true,
-        gyroControls: false,
-        minHeight: 200.00,
-        minWidth: 200.00,
-        scale: 1.00,
-        scaleMobile: 1.00,
-        color: 0x40000,
-        backgroundColor: 0xdedede,
-        points: 12.00,
-        maxDistance: 12.00,
-        spacing: 12.00
-      });
-    </script>
+    
   </body>
 </html>


### PR DESCRIPTION
Move Vanta background to homepage only and change its background color to white.

---
<a href="https://cursor.com/background-agent?bcId=bc-7a4af044-ff6f-448e-8474-883d18712158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7a4af044-ff6f-448e-8474-883d18712158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

