### PR TITLE
Remove blue shadow from circular menu

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -26,8 +26,8 @@ body{
 /* Clean container: no big rectangle behind the grid */
 .menu-grid{ text-align:center; display:grid; grid-template-columns: repeat(4, minmax(120px, 1fr)); gap:28px; max-width:1100px; width:100%; justify-items:center; background:transparent; border:0; box-shadow:none; }
 /* Perfect circular tiles */
-.menu-item{ display:flex; flex-direction:column; align-items:center; justify-content:center; width:min(100%, 200px); aspect-ratio:1 / 1; border-radius:50%; text-decoration:none; color:var(--text); background:var(--card); border:1px solid var(--stroke); box-shadow: 0 10px 30px rgba(0,0,0,0.06), 0 0 0 6px rgba(10,132,255,0.06), 0 0 24px rgba(10,132,255,0.14), inset 0 1px 0 rgba(255,255,255,0.6); transition: transform .25s ease, box-shadow .25s ease, background .25s ease; justify-self:center; }
-.menu-item:hover{ transform: translateY(-4px); box-shadow: 0 18px 40px rgba(0,0,0,0.10), 0 0 0 8px rgba(10,132,255,0.08), 0 0 34px rgba(10,132,255,0.22); }
+.menu-item{ display:flex; flex-direction:column; align-items:center; justify-content:center; width:min(100%, 200px); aspect-ratio:1 / 1; border-radius:50%; text-decoration:none; color:var(--text); background:var(--card); border:1px solid var(--stroke); box-shadow: 0 10px 30px rgba(0,0,0,0.06), inset 0 1px 0 rgba(255,255,255,0.6); transition: transform .25s ease, box-shadow .25s ease, background .25s ease; justify-self:center; }
+.menu-item:hover{ transform: translateY(-4px); box-shadow: 0 18px 40px rgba(0,0,0,0.10); }
 .menu-item .icon{ font-size:28px; margin-bottom:10px; }
 .menu-item .label{ font-weight:600; letter-spacing:0.2px; }
 


### PR DESCRIPTION
Remove blue shadow from circular menu items to restore their previous appearance.

---
<a href="https://cursor.com/background-agent?bcId=bc-89b88a9f-ef79-4dd5-9bd5-9a3e5d1d35f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-89b88a9f-ef79-4dd5-9bd5-9a3e5d1d35f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

