### PR TITLE
Set default google satellite basemap

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -20,7 +20,7 @@ const center = fromLonLat(centerLonLat);
 
 const osm = new TileLayer({ 
   source: new OSM(), 
-  visible: true 
+  visible: false 
 });
 
 const cartoDB = new TileLayer({
@@ -43,9 +43,30 @@ const esriSat = new TileLayer({
   visible: false
 });
 
+// Google basemaps
+const googleSat = new TileLayer({
+  source: new XYZ({
+    url: 'https://mt1.google.com/vt/lyrs=s&x={x}&y={y}&z={z}',
+    attributions: '© Google',
+    maxZoom: 21,
+    crossOrigin: 'anonymous'
+  }),
+  visible: true
+});
+
+const googleHybrid = new TileLayer({
+  source: new XYZ({
+    url: 'https://mt1.google.com/vt/lyrs=y&x={x}&y={y}&z={z}',
+    attributions: '© Google',
+    maxZoom: 21,
+    crossOrigin: 'anonymous'
+  }),
+  visible: false
+});
+
 const map = new Map({
   target: 'map',
-  layers: [osm, cartoDB, esriSat],
+  layers: [googleSat, googleHybrid, osm, cartoDB, esriSat],
   view: new View({ center, zoom: 11 }),
   // Remove default OL UI controls; we provide custom ones in the UI.
   // Also hides basemap attribution text.
@@ -54,7 +75,7 @@ const map = new Map({
 });
 
 // Error handling for tile loading
-[osm, cartoDB, esriSat].forEach((layer, idx) => {
+[googleSat, googleHybrid, osm, cartoDB, esriSat].forEach((layer, idx) => {
   const source = layer.getSource();
   source.on('tileloaderror', (event) => {
     console.warn(`Tile loading error for layer ${idx}:`, event);
@@ -99,6 +120,8 @@ map.addLayer(pointsLayer);
 
 // Basemap switching
 function setBasemap(name){
+  googleSat.setVisible(name === 'g_sat');
+  googleHybrid.setVisible(name === 'g_hybrid');
   osm.setVisible(name === 'osm');
   cartoDB.setVisible(name === 'carto');
   esriSat.setVisible(name === 'sat');

--- a/map.html
+++ b/map.html
@@ -35,7 +35,9 @@
       <div style="margin-top:8px;">
         <div>
           <div style="font-weight:600; margin:8px 0 6px;">Basemap</div>
-          <label><input type="radio" name="basemap" value="osm" checked /> OpenStreetMap</label><br/>
+          <label><input type="radio" name="basemap" value="g_sat" checked /> Google Satellite</label><br/>
+          <label><input type="radio" name="basemap" value="g_hybrid" /> Google Hybrid</label><br/>
+          <label><input type="radio" name="basemap" value="osm" /> OpenStreetMap</label><br/>
           <label><input type="radio" name="basemap" value="carto" /> CartoDB Light</label><br/>
           <label><input type="radio" name="basemap" value="sat" /> ESRI Satellite</label>
         </div>


### PR DESCRIPTION
Add Google Satellite and Google Hybrid basemaps, setting Google Satellite as the default and first option in the basemap list.

---
<a href="https://cursor.com/background-agent?bcId=bc-47d6bfce-c3a6-4dd7-b4b9-812c7c1e2e3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-47d6bfce-c3a6-4dd7-b4b9-812c7c1e2e3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

