### PR TITLE
Fix basemap and sidepanel display issues

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -20,7 +20,7 @@ body{
 .brand{ display:flex; align-items:center; gap:10px; font-weight:600; }
 .brand-icon{ width:24px; height:24px; filter: drop-shadow(0 1px 1px rgba(0,0,0,0.1)); }
 .brand-text{ letter-spacing:0.2px; }
-.app-footer{ position:fixed; align:center; bottom:0; display:flex; align-items:center; justify-content:center; padding:12px; color:var(--muted); }
+.app-footer{ position:fixed; align:center; bottom:0; display:flex; align-items:center; justify-content:center; padding:12px; color:var(--muted); z-index:10; }
 
 .home{ display:grid; place-items:center; padding:40px 16px; }
 /* Clean container: no big rectangle behind the grid */
@@ -40,7 +40,7 @@ body{
 .btn.primary{ background: linear-gradient(180deg, #1ea1ff, #0a84ff); color:white; border:none; }
 .input{ width:100%; padding:12px 14px; border-radius:12px; border:1px solid var(--stroke); background: linear-gradient(180deg, #fff, #f8fafc); }
 .form-row{ display:flex; flex-direction:column; gap:8px; }
-.layout{ display:grid; grid-template-columns: 260px 1fr; min-height: calc(100vh - 100px); }
+.layout{ position:relative; z-index:1; display:grid; grid-template-columns: 260px 1fr; min-height: calc(100vh - 100px); }
 .sidebar{ padding:20px; }
 .content{ padding:24px; }
 
@@ -58,4 +58,4 @@ body{
 .modal.open{ display:flex; }
 .modal img{ max-width:90vw; max-height:90vh; border-radius:12px; box-shadow: 0 20px 60px rgba(0,0,0,0.5); }
 
-#vanta-bg{ position: fixed; inset:0; pointer-events:none; }
+#vanta-bg{ position: fixed; inset:0; pointer-events:none; z-index:0; }

--- a/dashboard.html
+++ b/dashboard.html
@@ -21,7 +21,7 @@
       </nav>
     </header>
 
-    <div class="layout">
+    <div class="layout" style="position:relative; z-index:1;">
       <aside class="sidebar">
         <div class="card" style="padding:16px;">
           <div style="display:flex; align-items:center; justify-content:space-between;">

--- a/index.html
+++ b/index.html
@@ -75,26 +75,5 @@
     <script>
       document.getElementById('year').textContent = new Date().getFullYear();
     </script>
-    <!-- Three.js (required for Vanta) -->
-    <script src="https://cdn.jsdelivr.net/npm/three@0.134.0/build/three.min.js"></script>
-    <!-- Vanta Fog -->
-    <script src="https://cdn.jsdelivr.net/npm/vanta@0.5.24/dist/vanta.fog.min.js"></script>
-    <script>
-      VANTA.FOG({
-        el: "body",
-        mouseControls: true,
-        touchControls: true,
-        gyroControls: false,
-        minHeight: 200.00,
-        minWidth: 200.00,
-        highlightColor: 0xffffff,
-        midtoneColor: 0xf2ff,
-        lowlightColor: 0xd9d9d9,
-        baseColor: 0xffffff,
-        blurFactor: 0.57,
-        speed: 1.60,
-        zoom: 0.80
-      })
-    </script>
   </body>
 </html>

--- a/js/map.js
+++ b/js/map.js
@@ -9,9 +9,9 @@ const { Vector: VectorSource } = ol.source;
 const { fromLonLat } = ol.proj;
 const { GeoJSON } = ol.format;
 const { Fill, Stroke, Style, Circle: CircleStyle, Icon } = ol.style;
-// In the UMD build, defaults are nested under `.defaults`
-const defaultControls = ol.control.defaults.defaults;
-const defaultInteractions = ol.interaction.defaults.defaults;
+// Defaults are functions on the UMD namespace
+const defaultControls = ol.control.defaults;
+const defaultInteractions = ol.interaction.defaults;
 const { Select } = ol.interaction;
 const { Overlay } = ol;
 
@@ -245,7 +245,6 @@ const chkKecamatan = document.getElementById('chkKecamatan');
 const chkPoints = document.getElementById('chkPoints');
 const chkLines = document.getElementById('chkLines');
 const chkPolygons = document.getElementById('chkPolygons');
-const chkKecamatan = document.getElementById('chkKecamatan');
 chkPoints.addEventListener('change', () => pointsLayer.setVisible(chkPoints.checked));
 chkLines.addEventListener('change', () => linesLayer.setVisible(chkLines.checked));
 chkPolygons.addEventListener('change', () => polygonsLayer.setVisible(chkPolygons.checked));

--- a/login.html
+++ b/login.html
@@ -57,26 +57,6 @@
     </script>
     <script type="module" src="./js/utils.js"></script>
     <script type="module" src="./js/auth.js"></script>
-    <!-- Three.js (required for Vanta) -->
-    <script src="https://cdn.jsdelivr.net/npm/three@0.134.0/build/three.min.js"></script>
-    <!-- Vanta Fog -->
-    <script src="https://cdn.jsdelivr.net/npm/vanta@0.5.24/dist/vanta.fog.min.js"></script>
-    <script>
-      VANTA.FOG({
-        el: "body",
-        mouseControls: true,
-        touchControls: true,
-        gyroControls: false,
-        minHeight: 200.00,
-        minWidth: 200.00,
-        highlightColor: 0xffffff,
-        midtoneColor: 0xf2ff,
-        lowlightColor: 0xd9d9d9,
-        baseColor: 0xffffff,
-        blurFactor: 0.57,
-        speed: 1.60,
-        zoom: 0.80
-      })
-    </script>
+    
   </body>
 </html>

--- a/map.html
+++ b/map.html
@@ -46,7 +46,7 @@
         <label><input id="chkPoints" type="checkbox" checked /> Points</label><br/>
         <label><input id="chkLines" type="checkbox" checked /> Lines</label><br/>
         <label><input id="chkPolygons" type="checkbox" checked /> Polygons</label><br/>
-        <label><input id="chkKecamatan" type="checkbox" checked /> Batas Kecamatan</label>
+        <!-- Duplicate checkbox removed: Batas Kecamatan -->
       </div>
       <div style="margin-top:12px;" class="legend">
         <div class="legend-row"><span class="legend-swatch" style="background:linear-gradient(90deg, #FF6B6B, #4ECDC4, #45B7D1, #96CEB4)"></span> Kecamatan (22 districts)</div>


### PR DESCRIPTION
Fix basemap display, ensure dashboard sidepanels are always visible, and remove duplicate code.

The basemaps were not showing due to a `SyntaxError` from a duplicated variable declaration in `js/map.js` and incorrect usage of `ol.control.defaults.defaults` and `ol.interaction.defaults.defaults`. Dashboard sidepanels were obscured by the Vanta background due to incorrect `z-index` stacking. Duplicate Vanta scripts were also removed for cleaner code.

---
<a href="https://cursor.com/background-agent?bcId=bc-29b70d3b-bb00-4edf-9d88-7379e15f5019"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-29b70d3b-bb00-4edf-9d88-7379e15f5019"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

