### PR TITLE
Fix basemap and sidepanel display issues

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -58,4 +58,4 @@ body{
 .modal.open{ display:flex; }
 .modal img{ max-width:90vw; max-height:90vh; border-radius:12px; box-shadow: 0 20px 60px rgba(0,0,0,0.5); }
 
-#vanta-bg{ position: fixed; inset:0; pointer-events:none; }
+#vanta-bg{ position: fixed; inset:0; pointer-events:none; z-index:-1; }

--- a/index.html
+++ b/index.html
@@ -75,26 +75,6 @@
     <script>
       document.getElementById('year').textContent = new Date().getFullYear();
     </script>
-    <!-- Three.js (required for Vanta) -->
-    <script src="https://cdn.jsdelivr.net/npm/three@0.134.0/build/three.min.js"></script>
-    <!-- Vanta Fog -->
-    <script src="https://cdn.jsdelivr.net/npm/vanta@0.5.24/dist/vanta.fog.min.js"></script>
-    <script>
-      VANTA.FOG({
-        el: "body",
-        mouseControls: true,
-        touchControls: true,
-        gyroControls: false,
-        minHeight: 200.00,
-        minWidth: 200.00,
-        highlightColor: 0xffffff,
-        midtoneColor: 0xf2ff,
-        lowlightColor: 0xd9d9d9,
-        baseColor: 0xffffff,
-        blurFactor: 0.57,
-        speed: 1.60,
-        zoom: 0.80
-      })
-    </script>
+    <!-- Removed duplicate Vanta initialization to avoid double overlays -->
   </body>
 </html>

--- a/js/map.js
+++ b/js/map.js
@@ -8,10 +8,14 @@ const { Tile: TileLayer, Vector: VectorLayer } = ol.layer;
 const { Vector: VectorSource } = ol.source;
 const { fromLonLat } = ol.proj;
 const { GeoJSON } = ol.format;
-const { Fill, Stroke, Style, Circle: CircleStyle, Icon } = ol.style;
-// In the UMD build, defaults are nested under `.defaults`
-const defaultControls = ol.control.defaults.defaults;
-const defaultInteractions = ol.interaction.defaults.defaults;
+const { Fill, Stroke, Style, Circle: CircleStyle } = ol.style;
+// Support both OL UMD shapes: `.defaults.defaults` (module->fn) and `.defaults` (fn)
+const defaultControls = (ol.control.defaults && ol.control.defaults.defaults)
+  ? ol.control.defaults.defaults
+  : ol.control.defaults;
+const defaultInteractions = (ol.interaction.defaults && ol.interaction.defaults.defaults)
+  ? ol.interaction.defaults.defaults
+  : ol.interaction.defaults;
 const { Select } = ol.interaction;
 const { Overlay } = ol;
 
@@ -91,41 +95,7 @@ function attachTileErrorFallback(layer){
 }
 [googleHybrid, googleSat, cartoDB, esriSat].forEach(attachTileErrorFallback);
 
-// Color palette for each NAMOBJ (22 distinct colors)
-const colorPalette = {
-  'BANGUNPURBA': '#FF6B6B',      // Coral Red
-  'BATANGKUIS': '#4ECDC4',       // Turquoise
-  'BERINGIN': '#45B7D1',         // Sky Blue
-  'BIRU-BIRU': '#96CEB4',        // Sage Green
-  'DELITUA': '#FFEAA7',          // Pale Yellow
-  'GALANG': '#DFE6E9',           // Light Gray
-  'GUNUNGMERIAH': '#74B9FF',     // Light Blue
-  'HAMPARANPERAK': '#A29BFE',    // Periwinkle
-  'KUTALIMBARU': '#FD79A8',      // Pink
-  'LABUHANDELI': '#FDCB6E',      // Orange Yellow
-  'LUBUKPAKAM': '#6C5CE7',       // Purple
-  'NAMORAMBE': '#00B894',        // Teal
-  'PAGARMERBAU': '#E17055',      // Terra Cotta
-  'PANCURBATU': '#55EFC4',       // Mint
-  'PANTAILABU': '#81ECEC',       // Cyan
-  'PATUMBAK': '#FAB1A0',         // Peach
-  'PERCUTSEITUAN': '#FF7675',    // Salmon
-  'SENEMBAHTANJUNGMUDA HILIR': '#FD79A8', // Rose
-  'SENEMBAHTANJUNGMUDA HULU': '#A29BFE',  // Lavender
-  'SIBOLANGIT': '#00CEC9',       // Aqua
-  'SUNGGAL': '#F8A5C2',          // Light Pink
-  'TANJUNGMORAWA': '#63CDDA'     // Ocean Blue
-};
-
-// Style function for kecamatan boundaries
-function kecamatanStyleFunction(feature) {
-  const namobj = feature.get('NAMOBJ');
-  const color = colorPalette[namobj] || '#CCCCCC'; // Default gray if not found
-  return new Style({
-    stroke: new Stroke({ color: '#333333', width: 2 }),
-    fill: new Fill({ color: color + '80' }) // Adding transparency (50%)
-  });
-}
+// (removed legacy, unused color/style function definitions)
 
 // Vector layers
 const pointStyle = new Style({
@@ -245,7 +215,6 @@ const chkKecamatan = document.getElementById('chkKecamatan');
 const chkPoints = document.getElementById('chkPoints');
 const chkLines = document.getElementById('chkLines');
 const chkPolygons = document.getElementById('chkPolygons');
-const chkKecamatan = document.getElementById('chkKecamatan');
 chkPoints.addEventListener('change', () => pointsLayer.setVisible(chkPoints.checked));
 chkLines.addEventListener('change', () => linesLayer.setVisible(chkLines.checked));
 chkPolygons.addEventListener('change', () => polygonsLayer.setVisible(chkPolygons.checked));

--- a/map.html
+++ b/map.html
@@ -46,7 +46,6 @@
         <label><input id="chkPoints" type="checkbox" checked /> Points</label><br/>
         <label><input id="chkLines" type="checkbox" checked /> Lines</label><br/>
         <label><input id="chkPolygons" type="checkbox" checked /> Polygons</label><br/>
-        <label><input id="chkKecamatan" type="checkbox" checked /> Batas Kecamatan</label>
       </div>
       <div style="margin-top:12px;" class="legend">
         <div class="legend-row"><span class="legend-swatch" style="background:linear-gradient(90deg, #FF6B6B, #4ECDC4, #45B7D1, #96CEB4)"></span> Kecamatan (22 districts)</div>


### PR DESCRIPTION
Fix basemap display, restore dashboard sidepanel visibility, and clean up duplicate/unused code.

Basemap display was broken due to incorrect access of OpenLayers default controls/interactions and a duplicated checkbox/variable. Dashboard sidepanels were obscured by a Vanta background that was initialized twice and lacked a proper z-index, causing it to overlay UI elements. Code cleanup involved removing redundant Vanta initialization and an unused color palette/style function.

---
<a href="https://cursor.com/background-agent?bcId=bc-061106d3-a8f8-4788-be5f-05810db0fb6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-061106d3-a8f8-4788-be5f-05810db0fb6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

