### PR TITLE
Fix and clean map geojson data

### DIFF
--- a/map.html
+++ b/map.html
@@ -43,15 +43,8 @@
         </div>
         <div style="font-weight:600; margin:12px 0 6px;">Operational Layers</div>
         <label><input id="chkKecamatan" type="checkbox" checked /> Kecamatan Boundaries</label><br/>
-        <label><input id="chkPoints" type="checkbox" checked /> Points</label><br/>
-        <label><input id="chkLines" type="checkbox" checked /> Lines</label><br/>
-        <label><input id="chkPolygons" type="checkbox" checked /> Polygons</label><br/>
       </div>
       <div style="margin-top:12px;" class="legend">
-        <div class="legend-row"><span class="legend-swatch" style="background:linear-gradient(90deg, #FF6B6B, #4ECDC4, #45B7D1, #96CEB4)"></span> Kecamatan (22 districts)</div>
-        <div class="legend-row"><span class="legend-swatch" style="background:#ef4444"></span> Points</div>
-        <div class="legend-row"><span class="legend-swatch" style="background:#10b981"></span> Lines</div>
-        <div class="legend-row"><span class="legend-swatch" style="background:#3b82f6"></span> Polygons</div>
         <div class="legend-row"><span class="legend-swatch" style="background:#111827;border:1px solid #111827"></span> Batas Kecamatan (by NAMOBJ)</div>
       </div>
     </div>


### PR DESCRIPTION
Remove unused point, line, and polygon GeoJSON layers and fix `batas_kecamatan.geojson` visibility by adding `dataProjection` and fitting the map view.

---
<a href="https://cursor.com/background-agent?bcId=bc-918c996c-4297-4fc5-bff2-7b30079f148b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-918c996c-4297-4fc5-bff2-7b30079f148b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

