### PR TITLE
Investigate and clean map display issues

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -152,7 +152,7 @@ function kecamatanStyle(feature){
   return style;
 }
 
-const kecamatanLayer = new VectorLayer({ source: new VectorSource(), style: kecamatanStyle, visible: true });
+const kecamatanLayer = new VectorLayer({ source: new VectorSource(), style: kecamatanStyle, visible: true, zIndex: 10 });
 
 // Add kecamatan layer to map
 map.addLayer(kecamatanLayer);
@@ -163,7 +163,7 @@ map.addLayer(kecamatanLayer);
   const fmt = new GeoJSON();
   // Load Batas Kecamatan
   kecamatanLayer.getSource().addFeatures(
-    fmt.readFeatures(batas, { featureProjection: map.getView().getProjection() })
+    fmt.readFeatures(batas, { dataProjection: 'EPSG:4326', featureProjection: map.getView().getProjection() })
   );
   // Keep explicit center; avoid auto-fit overriding requested center
 })();

--- a/map.html
+++ b/map.html
@@ -44,10 +44,7 @@
         <div style="font-weight:600; margin:12px 0 6px;">Operational Layers</div>
         <label><input id="chkKecamatan" type="checkbox" checked /> Kecamatan Boundaries</label><br/>
       </div>
-      <div style="margin-top:12px;" class="legend">
-        <div class="legend-row"><span class="legend-swatch" style="background:linear-gradient(90deg, #FF6B6B, #4ECDC4, #45B7D1, #96CEB4)"></span> Kecamatan (22 districts)</div>
-        <div class="legend-row"><span class="legend-swatch" style="background:#111827;border:1px solid #111827"></span> Batas Kecamatan (by NAMOBJ)</div>
-      </div>
+      <div style="margin-top:12px;" class="legend"></div>
     </div>
 
     <!-- Image modal -->


### PR DESCRIPTION
Fix `batas_kecamatan.geojson` layer visibility and remove unused legend labels.

The GeoJSON layer was not appearing due to missing `dataProjection: 'EPSG:4326'` during feature reading and an unset `zIndex` which could place it beneath basemaps.

---
<a href="https://cursor.com/background-agent?bcId=bc-63353bed-3c7f-42f7-895a-c2a4ca879339"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-63353bed-3c7f-42f7-895a-c2a4ca879339"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

