### PR TITLE
Investigate and clean map display issues

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -152,19 +152,32 @@ function kecamatanStyle(feature){
   return style;
 }
 
-const kecamatanLayer = new VectorLayer({ source: new VectorSource(), style: kecamatanStyle, visible: true });
+const kecamatanLayer = new VectorLayer({
+  source: new VectorSource(),
+  style: kecamatanStyle,
+  visible: true,
+  zIndex: 1000
+});
 
 // Add kecamatan layer to map
 map.addLayer(kecamatanLayer);
 
 // Load data
 (async function loadData(){
-  const batas = await fetchJSON('./data/batas_kecamatan.geojson');
-  const fmt = new GeoJSON();
-  // Load Batas Kecamatan
-  kecamatanLayer.getSource().addFeatures(
-    fmt.readFeatures(batas, { featureProjection: map.getView().getProjection() })
-  );
+  try{
+    const batas = await fetchJSON('./data/batas_kecamatan.geojson');
+    const fmt = new GeoJSON();
+    const features = fmt.readFeatures(batas, {
+      dataProjection: 'EPSG:4326',
+      featureProjection: map.getView().getProjection()
+    });
+    if(!features || features.length === 0){
+      console.warn('batas_kecamatan.geojson parsed with 0 features');
+    }
+    kecamatanLayer.getSource().addFeatures(features);
+  }catch(err){
+    console.error('Failed to load ./data/batas_kecamatan.geojson', err);
+  }
   // Keep explicit center; avoid auto-fit overriding requested center
 })();
 

--- a/map.html
+++ b/map.html
@@ -44,10 +44,7 @@
         <div style="font-weight:600; margin:12px 0 6px;">Operational Layers</div>
         <label><input id="chkKecamatan" type="checkbox" checked /> Kecamatan Boundaries</label><br/>
       </div>
-      <div style="margin-top:12px;" class="legend">
-        <div class="legend-row"><span class="legend-swatch" style="background:linear-gradient(90deg, #FF6B6B, #4ECDC4, #45B7D1, #96CEB4)"></span> Kecamatan (22 districts)</div>
-        <div class="legend-row"><span class="legend-swatch" style="background:#111827;border:1px solid #111827"></span> Batas Kecamatan (by NAMOBJ)</div>
-      </div>
+      <div style="margin-top:12px;" class="legend"></div>
     </div>
 
     <!-- Image modal -->


### PR DESCRIPTION
Fix `batas_kecamatan.geojson` not displaying on the map and remove unused legend labels.

The `batas_kecamatan.geojson` layer was not visible due to missing `dataProjection` for correct coordinate transformation and an insufficient `zIndex` to ensure it rendered above the basemap. This PR explicitly sets `dataProjection: 'EPSG:4326'` and `zIndex: 1000` for the layer.

---
<a href="https://cursor.com/background-agent?bcId=bc-1b41ca82-19d6-4047-a860-02af3c7017c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1b41ca82-19d6-4047-a860-02af3c7017c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

