### PR TITLE
Fix geojson file not showing on maps

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -159,11 +159,23 @@ map.addLayer(kecamatanLayer);
 
 // Load data
 (async function loadData(){
-  const batas = await fetchJSON('./data/batas_kecamatan.geojson');
+  const batas = await fetchJSON('./data/batas_kecamatan.json');
   const fmt = new GeoJSON();
+  // Normalize to FeatureCollection if the file is an array of Features
+  let batasGeoJSON;
+  if(Array.isArray(batas)){
+    batasGeoJSON = { type: 'FeatureCollection', features: batas };
+  } else if(batas && batas.type === 'FeatureCollection' && Array.isArray(batas.features)){
+    batasGeoJSON = batas;
+  } else if(batas && Array.isArray(batas.features)){
+    batasGeoJSON = { type: 'FeatureCollection', features: batas.features };
+  } else {
+    console.warn('Unexpected GeoJSON format for batas_kecamatan.json', batas);
+    batasGeoJSON = { type: 'FeatureCollection', features: [] };
+  }
   // Load Batas Kecamatan
   kecamatanLayer.getSource().addFeatures(
-    fmt.readFeatures(batas, { dataProjection: 'EPSG:4326', featureProjection: map.getView().getProjection() })
+    fmt.readFeatures(batasGeoJSON, { dataProjection: 'EPSG:4326', featureProjection: map.getView().getProjection() })
   );
   // Keep explicit center; avoid auto-fit overriding requested center
 })();


### PR DESCRIPTION
Correct GeoJSON file path and normalize data to ensure map layers display correctly.

The map failed to display GeoJSON data because `js/map.js` was attempting to load a `.geojson` file that did not exist, while the actual data was present as a `.json` file. Additionally, the data structure might not always be a direct `FeatureCollection`, so normalization was added to ensure OpenLayers can parse it correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-27d3d796-b01d-45f3-b851-d5b0f833bf21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-27d3d796-b01d-45f3-b851-d5b0f833bf21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

